### PR TITLE
Added dependency badge for README file;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-sabre/http
+sabre/http [![Dependency Status](https://www.versioneye.com/php/sabre:http/2.0.1/badge.png)](https://www.versioneye.com/php/sabre:http/2.0.1)
 ==========
 
 This library provides a toolkit to make working with the HTTP protocol easier.


### PR DESCRIPTION
Hi, i found your library through your blog post & HN. It's nice library.

What do you think about adding VersionEye dependency badge into README? 
This badge shows a current state of dependencies and users can check out a related metadata when they click on the badge. As the author of `sabre-http`, you can also check out which [packages](https://www.versioneye.com/php/sabre:http/references) are already using yours library.
