### PR TITLE
Fix comment for phpcs

### DIFF
--- a/lib/Sabre/HTTP/Auth/AbstractAuth.php
+++ b/lib/Sabre/HTTP/Auth/AbstractAuth.php
@@ -61,8 +61,8 @@ abstract class AbstractAuth {
     abstract public function requireLogin();
 
     /**
-     * Returns the HTTP realm 
-     * 
+     * Returns the HTTP realm
+     *
      * @return string
      */
     public function getRealm() {


### PR DESCRIPTION
The latest stable version of phpcs (1.5.3) doesn’t find any error, but
the latest alpha (2.0.0a2) does. This change has been automatically
made by PHPCBF.
