### PR TITLE
For portability, add the `b` flag on php://temp and php://input

### DIFF
--- a/lib/Message.php
+++ b/lib/Message.php
@@ -48,7 +48,7 @@ abstract class Message implements MessageInterface {
 
         $body = $this->getBody();
         if (is_string($body) || is_null($body)) {
-            $stream = fopen('php://temp', 'r+');
+            $stream = fopen('php://temp', 'r+b');
             fwrite($stream, $body);
             rewind($stream);
             return $stream;

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -39,7 +39,7 @@ class Sapi {
     static function getRequest() {
 
         $r = self::createFromServerArray($_SERVER);
-        $r->setBody(fopen('php://input','r'));
+        $r->setBody(fopen('php://input','rb'));
         $r->setPostData($_POST);
         return $r;
 


### PR DESCRIPTION
From my own experience (with [`Hoa\File`](http://central.hoa-project.net/Resource/Library/File) for example), or from the [PHP documentation](http://php.net/fopen):
>  **Note**:
>
> For portability, it is strongly recommended that you always use the '`b`' flag when opening files with `fopen()`.

I strongly recommend to use the `b` flag, especially with Windows and specific encoding.