### PR TITLE
Simplify the `splitPath` regular expression

### DIFF
--- a/lib/URLUtil.php
+++ b/lib/URLUtil.php
@@ -110,7 +110,7 @@ class URLUtil {
     static function splitPath($path) {
 
         $matches = array();
-        if(preg_match('/^(?:(?:(.*)(?:\/+))?([^\/]+))(?:\/?)$/u',$path,$matches)) {
+        if(preg_match('/^(?:(.*)\/+)?([^\/]+)\/?$/u',$path,$matches)) {
             return array($matches[1],$matches[2]);
         } else {
             return array(null,null);


### PR DESCRIPTION
I have only removed unnecessary non-capturing groups. The final expression is more readable and therefore maintanable :-).
