### PR TITLE
306 is now unused

### DIFF
--- a/lib/Response.php
+++ b/lib/Response.php
@@ -36,7 +36,6 @@ class Response extends Message implements ResponseInterface {
         303 => 'See Other',
         304 => 'Not Modified',
         305 => 'Use Proxy',
-        306 => 'Reserved',
         307 => 'Temporary Redirect',
         308 => 'Permanent Redirect',
         400 => 'Bad Request',


### PR DESCRIPTION
Regarding http://tools.ietf.org/html/rfc7231#section-6.4.6:

> The 306 status code was defined in a previous version of this
> specification, is no longer used, and the code is reserved.
