### PR TITLE
`getCredentials` returns null if incomplete

### DIFF
--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -37,7 +37,13 @@ class Basic extends AbstractAuth {
             return null;
         }
 
-        return explode(':',base64_decode(substr($auth, 6)), 2);
+        $credentials = explode(':',base64_decode(substr($auth, 6)), 2);
+
+        if (2 !== count($credentials)) {
+            return null;
+        }
+
+        return $credentials;
 
     }
 

--- a/tests/HTTP/Auth/BasicTest.php
+++ b/tests/HTTP/Auth/BasicTest.php
@@ -22,6 +22,18 @@ class BasicTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testGetInvalidCredentialsColonMissing() {
+
+        $request = new Request('GET','/',array(
+            'Authorization' => 'Basic ' . base64_encode('userpass')
+        ));
+
+        $basic = new Basic('Dagger', $request, new Response());
+
+        $this->assertNull($basic->getCredentials($request));
+
+    }
+
     function testGetCredentialsNoheader() {
 
         $request = new Request('GET','/',array());


### PR DESCRIPTION
If the colon is missing (in `user:password`), `getCredentials` will return an array of one value instead of null whereas this is incorrect. We then check that the credentials form a pair of two values.