### PR TITLE
Close the body of a stream response after sending

### DIFF
--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -83,6 +83,10 @@ class Sapi {
             file_put_contents('php://output', $body);
         }
 
+        if (is_resource($body)) {
+            fclose($body);
+        }
+
     }
 
     /**


### PR DESCRIPTION
By closing the stream manually we make sure any streamwrapper for the stream has the chance to handle the fclose.