### PR TITLE
Respecting the Content-Length header when turning HTTP bodies into strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+4.2.1 (????-??-??)
+------------------
+
+* #56: `getBodyAsString` now returns at most as many bytes as the contents of
+  the `Content-Length` header. This allows users to pass much larger strings
+  without having to copy and truncate them.
+
+
 4.2.0 (2016-01-04)
 ------------------
 

--- a/lib/Message.php
+++ b/lib/Message.php
@@ -74,7 +74,12 @@ abstract class Message implements MessageInterface {
         if (is_null($body)) {
             return '';
         }
-        return stream_get_contents($body);
+        $contentLength = $this->getHeader('Content-Length');
+        if (null === $contentLength) {
+            return stream_get_contents($body);
+        } else {
+            return stream_get_contents($body, $contentLength);
+        }
 
     }
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -14,6 +14,6 @@ class Version {
     /**
      * Full version number
      */
-    const VERSION = '4.2.0';
+    const VERSION = '4.2.1';
 
 }

--- a/tests/HTTP/MessageTest.php
+++ b/tests/HTTP/MessageTest.php
@@ -57,7 +57,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 
         $body = fopen('php://memory', 'r+');
         fwrite($body, 'abcdefg');
-        fseek($body,2);
+        fseek($body, 2);
 
         $message = new MessageMock();
         $message->setBody($body);

--- a/tests/HTTP/MessageTest.php
+++ b/tests/HTTP/MessageTest.php
@@ -42,6 +42,33 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    /**
+     * It's possible that streams contains more data than the Content-Length.
+     *
+     * The request object should make sure to never emit more than
+     * Content-Length, if Content-Length is set.
+     *
+     * This is in particular useful when respoding to range requests with
+     * streams that represent files on the filesystem, as it's possible to just
+     * seek the stream to a certain point, set the content-length and let the
+     * request object do the rest.
+     */
+    function testLongStreamToStringBody() {
+
+        $body = fopen('php://memory', 'r+');
+        fwrite($body, 'abcdefg');
+        fseek($body,2);
+
+        $message = new MessageMock();
+        $message->setBody($body);
+        $message->setHeader('Content-Length', '4');
+
+        $this->assertEquals(
+            'cdef',
+            $message->getBodyAsString()
+        );
+
+    }
 
     function testGetEmptyBodyStream() {
 


### PR DESCRIPTION
`getBodyAsString` should only return at most as many bytes as the value of `Content-Length`, this allows users to pass much larger streams without having to copy and truncate them.