### PR TITLE
Handle stream body type requests

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -409,6 +409,12 @@ class Client extends EventEmitter {
                 $settings[CURLOPT_CUSTOMREQUEST] = 'GET';
                 $settings[CURLOPT_POSTFIELDS] = '';
                 $settings[CURLOPT_PUT] = false;
+                $body = $request->getBody();
+                if (is_resource($body)) {
+                    $settings[CURLOPT_HEADER] = 0;
+                    $settings[CURLOPT_FILE] = $request->getBody();
+                    error_log('SETTING CURLOPT_INFILE');
+                }
                 break;
             default :
                 $body = $request->getBody();

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -413,7 +413,6 @@ class Client extends EventEmitter {
                 if (is_resource($body)) {
                     $settings[CURLOPT_HEADER] = 0;
                     $settings[CURLOPT_FILE] = $request->getBody();
-                    error_log('SETTING CURLOPT_INFILE');
                 }
                 break;
             default :


### PR DESCRIPTION
Hi, the fix here allows me to use

```
$sabre = new Sabre\DAV\Client($settings);
$response = $sabre->send(new HTTP\Request('GET', $url, $headers, $body));

```
where $body is a file handle / stream.
The same functionality is supported for POST-ing large contents (files) but there is no other way for retrieving large contents directly to a file without wasting memory and probably dying in the process if the file is really large.