### PR TITLE
Various typo fixes and PHPDoc improvements

### DIFF
--- a/lib/Message.php
+++ b/lib/Message.php
@@ -189,7 +189,7 @@ abstract class Message implements MessageInterface {
     /**
      * Updates a HTTP header.
      *
-     * The case-sensitity of the name value must be retained as-is.
+     * The case-sensitivity of the name value must be retained as-is.
      *
      * If the header already existed, it will be overwritten.
      *
@@ -270,7 +270,7 @@ abstract class Message implements MessageInterface {
     /**
      * Removes a HTTP header.
      *
-     * The specified header name must be treated as case-insenstive.
+     * The specified header name must be treated as case-insensitive.
      * This method should return true if the header was successfully deleted,
      * and false if the header did not exist.
      *

--- a/lib/MessageDecoratorTrait.php
+++ b/lib/MessageDecoratorTrait.php
@@ -144,7 +144,7 @@ trait MessageDecoratorTrait {
     /**
      * Updates a HTTP header.
      *
-     * The case-sensitity of the name value must be retained as-is.
+     * The case-sensitivity of the name value must be retained as-is.
      *
      * If the header already existed, it will be overwritten.
      *
@@ -210,7 +210,7 @@ trait MessageDecoratorTrait {
     /**
      * Removes a HTTP header.
      *
-     * The specified header name must be treated as case-insenstive.
+     * The specified header name must be treated as case-insensitive.
      * This method should return true if the header was successfully deleted,
      * and false if the header did not exist.
      *

--- a/lib/MessageInterface.php
+++ b/lib/MessageInterface.php
@@ -44,7 +44,7 @@ interface MessageInterface {
     /**
      * Updates the body resource with a new stream.
      *
-     * @param resource $body
+     * @param resource|string $body
      * @return void
      */
     function setBody($body);

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -100,7 +100,6 @@ class Response extends Message implements ResponseInterface {
      * @param string|int $status
      * @param array $headers
      * @param resource $body
-     * @return void
      */
     function __construct($status = null, array $headers = null, $body = null) {
 
@@ -145,7 +144,7 @@ class Response extends Message implements ResponseInterface {
      * added.
      *
      * @param string|int $status
-     * @throws \InvalidArgumentExeption
+     * @throws \InvalidArgumentException
      * @return void
      */
     function setStatus($status) {

--- a/lib/ResponseInterface.php
+++ b/lib/ResponseInterface.php
@@ -37,7 +37,7 @@ interface ResponseInterface extends MessageInterface {
      * added.
      *
      * @param string|int $status
-     * @throws \InvalidArgumentExeption
+     * @throws \InvalidArgumentException
      * @return void
      */
     function setStatus($status);

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -79,7 +79,7 @@ function toDate(DateTime $dateTime) {
     // We need to clone it, as we don't want to affect the existing
     // DateTime.
     $dateTime = clone $dateTime;
-    $dateTime->setTimeZone(new \DateTimeZone('GMT'));
+    $dateTime->setTimezone(new \DateTimeZone('GMT'));
     return $dateTime->format('D, d M Y H:i:s \G\M\T');
 
 }


### PR DESCRIPTION
Various typo fixes and PHPDoc improvements.

Also `DateTime` has a method `setTimezone()`, not `setTimeZone()`.