### PR TITLE
MessageDecorator: fix removeHeader() return value

### DIFF
--- a/examples/asyncclient.php
+++ b/examples/asyncclient.php
@@ -10,8 +10,8 @@
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-use Sabre\HTTP\Request;
 use Sabre\HTTP\Client;
+use Sabre\HTTP\Request;
 
 // Find the autoloader
 $paths = [

--- a/examples/basicauth.php
+++ b/examples/basicauth.php
@@ -12,9 +12,9 @@ $userList = [
     "user2" => "password",
 ];
 
-use Sabre\HTTP\Sapi;
-use Sabre\HTTP\Response;
 use Sabre\HTTP\Auth;
+use Sabre\HTTP\Response;
+use Sabre\HTTP\Sapi;
 
 // Find the autoloader
 $paths = [

--- a/examples/client.php
+++ b/examples/client.php
@@ -8,8 +8,8 @@
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-use Sabre\HTTP\Request;
 use Sabre\HTTP\Client;
+use Sabre\HTTP\Request;
 
 // Find the autoloader
 $paths = [

--- a/examples/digestauth.php
+++ b/examples/digestauth.php
@@ -12,9 +12,9 @@ $userList = [
     "user2" => "password",
 ];
 
-use Sabre\HTTP\Sapi;
-use Sabre\HTTP\Response;
 use Sabre\HTTP\Auth;
+use Sabre\HTTP\Response;
+use Sabre\HTTP\Sapi;
 
 // Find the autoloader
 $paths = [

--- a/examples/reverseproxy.php
+++ b/examples/reverseproxy.php
@@ -11,8 +11,8 @@ $remoteUrl = 'http://example.org/';
 $myBaseUrl = '/reverseproxy.php';
 // $myBaseUrl = '/~evert/sabre/http/examples/reverseproxy.php/';
 
-use Sabre\HTTP\Sapi;
 use Sabre\HTTP\Client;
+use Sabre\HTTP\Sapi;
 
 // Find the autoloader
 $paths = [

--- a/lib/MessageDecoratorTrait.php
+++ b/lib/MessageDecoratorTrait.php
@@ -219,7 +219,7 @@ trait MessageDecoratorTrait {
      */
     function removeHeader($name) {
 
-        $this->inner->removeHeader($name);
+        return $this->inner->removeHeader($name);
 
     }
 

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -301,7 +301,7 @@ class Request extends Message implements RequestInterface {
             foreach ($value as $v) {
                 if ($key === 'Authorization') {
                     list($v) = explode(' ', $v, 2);
-                    $v  .= ' REDACTED';
+                    $v .= ' REDACTED';
                 }
                 $out .= $key . ": " . $v . "\r\n";
             }

--- a/tests/HTTP/MessageDecoratorTest.php
+++ b/tests/HTTP/MessageDecoratorTest.php
@@ -72,10 +72,13 @@ class MessageDecoratorTest extends \PHPUnit_Framework_TestCase {
             $this->outer->getHeaderAsArray('A')
         );
 
-        $this->outer->removeHeader('a');
+        $success = $this->outer->removeHeader('a');
 
+        $this->assertTrue($success);
         $this->assertNull($this->inner->getHeader('A'));
         $this->assertNull($this->outer->getHeader('A'));
+
+        $this->assertFalse($this->outer->removeHeader('i-dont-exist'));
     }
 
     function testHttpVersion() {

--- a/tests/HTTP/SapiTest.php
+++ b/tests/HTTP/SapiTest.php
@@ -33,10 +33,10 @@ class SapiTest extends \PHPUnit_Framework_TestCase {
     function testConstructPHPAuth() {
 
         $request = Sapi::createFromServerArray([
-            'REQUEST_URI'     => '/foo',
-            'REQUEST_METHOD'  => 'GET',
-            'PHP_AUTH_USER'   => 'user',
-            'PHP_AUTH_PW'     => 'pass',
+            'REQUEST_URI'    => '/foo',
+            'REQUEST_METHOD' => 'GET',
+            'PHP_AUTH_USER'  => 'user',
+            'PHP_AUTH_PW'    => 'pass',
         ]);
 
         $this->assertEquals('GET', $request->getMethod());

--- a/tests/HTTP/URLUtilTest.php
+++ b/tests/HTTP/URLUtilTest.php
@@ -97,18 +97,18 @@ class URLUtilTest extends \PHPUnit_Framework_TestCase{
 
         $strings = [
 
-            // input                    // expected result
-            '/foo/bar'                 => ['/foo','bar'],
-            '/foo/bar/'                => ['/foo','bar'],
-            'foo/bar/'                 => ['foo','bar'],
-            'foo/bar'                  => ['foo','bar'],
-            'foo/bar/baz'              => ['foo/bar','baz'],
-            'foo/bar/baz/'             => ['foo/bar','baz'],
-            'foo'                      => ['','foo'],
-            'foo/'                     => ['','foo'],
-            '/foo/'                    => ['','foo'],
-            '/foo'                     => ['','foo'],
-            ''                         => [null,null],
+            // input       // expected result
+            '/foo/bar'     => ['/foo','bar'],
+            '/foo/bar/'    => ['/foo','bar'],
+            'foo/bar/'     => ['foo','bar'],
+            'foo/bar'      => ['foo','bar'],
+            'foo/bar/baz'  => ['foo/bar','baz'],
+            'foo/bar/baz/' => ['foo/bar','baz'],
+            'foo'          => ['','foo'],
+            'foo/'         => ['','foo'],
+            '/foo/'        => ['','foo'],
+            '/foo'         => ['','foo'],
+            ''             => [null,null],
 
             // UTF-8
             "/\xC3\xA0fo\xC3\xB3/bar"  => ["/\xC3\xA0fo\xC3\xB3",'bar'],


### PR DESCRIPTION
`MessageDecoratorTrain::removeHeader()` should return bool as it's PHPDoc stats "This method should return true if the header was successfully deleted, and false if the header did not exist").

Currently this method doesn't return anything and this PR fixes the issue.