### PR TITLE
The $uri and $method params are now required when setting up Request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ ChangeLog
   its functions moved to the `sabre/uri` package.
 * Removed `Util` class. Most of its functions moved to the `functions.php`
   file.
+* #68: The `$method` and `$uri` arguments when constructing a Request object
+  are now required.
 
 
 4.2.1 (2016-01-06)

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -2,6 +2,7 @@
 
 namespace Sabre\HTTP;
 
+use LogicException;
 use Sabre\Uri;
 
 /**
@@ -35,12 +36,12 @@ class Request extends Message implements RequestInterface {
      *
      * @param resource|callable|string $body
      */
-    function __construct(string $method = null, string $url = null, array $headers = null, $body = null) {
+    function __construct(string $method, string $url, array $headers = [], $body = null) {
 
-        if (!is_null($method))      $this->setMethod($method);
-        if (!is_null($url))         $this->setUrl($url);
-        if (!is_null($headers))     $this->setHeaders($headers);
-        if (!is_null($body))        $this->setBody($body);
+        $this->setMethod($method);
+        $this->setUrl($url);
+        $this->setHeaders($headers);
+        $this->setBody($body);
 
     }
 
@@ -101,6 +102,8 @@ class Request extends Message implements RequestInterface {
 
     }
 
+    protected $absoluteUrl;
+
     /**
      * Sets the absolute url.
      *
@@ -116,6 +119,13 @@ class Request extends Message implements RequestInterface {
      * Returns the absolute url.
      */
     function getAbsoluteUrl() : string {
+
+        if (!$this->absoluteUrl) {
+            // Guessing we're a http endpoint.
+            $this->absoluteUrl = 'http://' .
+                ($this->getHeader('Host') ?? 'localhost') .
+                $this->getUrl();
+        }
 
         return $this->absoluteUrl;
 

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\HTTP;
 
+use InvalidArgumentException;
+
 /**
  * PHP SAPI
  *
@@ -94,6 +96,8 @@ class Sapi {
     /**
      * This static method will create a new Request object, based on a PHP
      * $_SERVER array.
+     *
+     * REQUEST_URI and REQUEST_METHOD are required.
      */
     static function createFromServerArray(array $serverArray) : Request {
 
@@ -182,6 +186,13 @@ class Sapi {
 
         }
 
+        if (is_null($url)) {
+            throw new InvalidArgumentException('The _SERVER array must have a REQUEST_URI key');
+        }
+
+        if (is_null($method)) {
+            throw new InvalidArgumentException('The _SERVER array must have a REQUEST_METHOD key');
+        }
         $r = new Request($method, $url, $headers);
         $r->setHttpVersion($httpVersion);
         $r->setRawServerData($serverArray);

--- a/tests/HTTP/Auth/AWSTest.php
+++ b/tests/HTTP/Auth/AWSTest.php
@@ -27,7 +27,7 @@ class AWSTest extends \PHPUnit_Framework_TestCase {
     function setUp() {
 
         $this->response = new Response();
-        $this->request = new Request();
+        $this->request = new Request('GET', '/');
         $this->auth = new AWS(self::REALM, $this->request, $this->response);
 
     }

--- a/tests/HTTP/Auth/BasicTest.php
+++ b/tests/HTTP/Auth/BasicTest.php
@@ -57,7 +57,9 @@ class BasicTest extends \PHPUnit_Framework_TestCase {
     function testRequireLogin() {
 
         $response = new Response();
-        $basic = new Basic('Dagger', new Request(), $response);
+        $request = new Request('GET', '/');
+
+        $basic = new Basic('Dagger', $request, $response);
 
         $basic->requireLogin();
 

--- a/tests/HTTP/Auth/BearerTest.php
+++ b/tests/HTTP/Auth/BearerTest.php
@@ -45,7 +45,8 @@ class BearerTest extends \PHPUnit_Framework_TestCase {
     function testRequireLogin() {
 
         $response = new Response();
-        $bearer = new Bearer('Dagger', new Request(), $response);
+        $request = new Request('GET', '/');
+        $bearer = new Bearer('Dagger', $request, $response);
 
         $bearer->requireLogin();
 

--- a/tests/HTTP/Auth/DigestTest.php
+++ b/tests/HTTP/Auth/DigestTest.php
@@ -29,7 +29,7 @@ class DigestTest extends \PHPUnit_Framework_TestCase {
     function setUp() {
 
         $this->response = new Response();
-        $this->request = new Request();
+        $this->request = new Request('GET', '/');
         $this->auth = new Digest(self::REALM, $this->request, $this->response);
 
 

--- a/tests/HTTP/MessageDecoratorTest.php
+++ b/tests/HTTP/MessageDecoratorTest.php
@@ -9,7 +9,7 @@ class MessageDecoratorTest extends \PHPUnit_Framework_TestCase {
 
     function setUp() {
 
-        $this->inner = new Request();
+        $this->inner = new Request('GET', '/');
         $this->outer = new RequestDecorator($this->inner);
 
     }

--- a/tests/HTTP/RequestDecoratorTest.php
+++ b/tests/HTTP/RequestDecoratorTest.php
@@ -9,7 +9,7 @@ class RequestDecoratorTest extends \PHPUnit_Framework_TestCase {
 
     function setUp() {
 
-        $this->inner = new Request();
+        $this->inner = new Request('GET', '/');
         $this->outer = new RequestDecorator($this->inner);
 
     }

--- a/tests/HTTP/RequestTest.php
+++ b/tests/HTTP/RequestTest.php
@@ -40,6 +40,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
      */
     function testCreateFromPHPRequest() {
 
+        $_SERVER['REQUEST_URI'] = '/';
         $_SERVER['REQUEST_METHOD'] = 'PUT';
 
         $request = Sapi::getRequest();
@@ -49,19 +50,17 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 
     function testGetAbsoluteUrl() {
 
-        $s = [
-            'HTTP_HOST'   => 'sabredav.org',
-            'REQUEST_URI' => '/foo'
-        ];
-
-        $r = Sapi::createFromServerArray($s);
+        $r = new Request('GET', '/foo', [
+            'Host' => 'sabredav.org',
+        ]);
 
         $this->assertEquals('http://sabredav.org/foo', $r->getAbsoluteUrl());
 
         $s = [
-            'HTTP_HOST'   => 'sabredav.org',
-            'REQUEST_URI' => '/foo',
-            'HTTPS'       => 'on',
+            'HTTP_HOST'      => 'sabredav.org',
+            'REQUEST_URI'    => '/foo',
+            'REQUEST_METHOD' => 'GET',
+            'HTTPS'          => 'on',
         ];
 
         $r = Sapi::createFromServerArray($s);
@@ -75,7 +74,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
         $post = [
             'bla' => 'foo',
         ];
-        $r = new Request();
+        $r = new Request('POST', '/');
         $r->setPostData($post);
         $this->assertEquals($post, $r->getPostData());
 
@@ -83,7 +82,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 
     function testGetPath() {
 
-        $request = new Request();
+        $request = new Request('GET', '/foo/bar/');
         $request->setBaseUrl('/foo');
         $request->setUrl('/foo/bar/');
 
@@ -93,9 +92,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 
     function testGetPathStrippedQuery() {
 
-        $request = new Request();
+        $request = new Request('GET', '/foo/bar?a=B');
         $request->setBaseUrl('/foo');
-        $request->setUrl('/foo/bar/?a=b');
 
         $this->assertEquals('bar', $request->getPath());
 
@@ -103,9 +101,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 
     function testGetPathMissingSlash() {
 
-        $request = new Request();
+        $request = new Request('GET', '/foo');
         $request->setBaseUrl('/foo/');
-        $request->setUrl('/foo');
 
         $this->assertEquals('', $request->getPath());
 
@@ -116,9 +113,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
      */
     function testGetPathOutsideBaseUrl() {
 
-        $request = new Request();
+        $request = new Request('GET', '/bar/');
         $request->setBaseUrl('/foo/');
-        $request->setUrl('/bar/');
 
         $request->getPath();
 


### PR DESCRIPTION
This ensures that it's not possible to create a Request object that's
not valid.