### PR TITLE
Sending encoding="UTF-8" on basic auth challenges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ ChangeLog
   to `CLI`.
 * The HTTP response is now initialized with HTTP code `500` instead of `null`,
   so if it's not changed, it will be emitted as 500.
+* #69: Sending `charset="UTF-8"` on Basic authentiation challenges per
+  [rfc7617][rfc7617].
 
 
 4.2.1 (2016-01-06)
@@ -268,4 +270,5 @@ Before 2.0.0, this package was built-into SabreDAV, where it first appeared in
 January 2009.
 
 [psr-http]: https://github.com/php-fig/fig-standards/blob/master/proposed/http-message.md
-[rfc-7240]: http://tools.ietf.org/html/rfc7240
+[rfc7240]: http://tools.ietf.org/html/rfc7240
+[rfc7617]: https://tools.ietf.org/html/rfc7617

--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -55,7 +55,7 @@ class Basic extends AbstractAuth {
      */
     function requireLogin() {
 
-        $this->response->addHeader('WWW-Authenticate', 'Basic realm="' . $this->realm . '"');
+        $this->response->addHeader('WWW-Authenticate', 'Basic realm="' . $this->realm . '", charset="UTF-8"');
         $this->response->setStatus(401);
 
     }

--- a/tests/HTTP/Auth/BasicTest.php
+++ b/tests/HTTP/Auth/BasicTest.php
@@ -63,7 +63,7 @@ class BasicTest extends \PHPUnit_Framework_TestCase {
 
         $basic->requireLogin();
 
-        $this->assertEquals('Basic realm="Dagger"', $response->getHeader('WWW-Authenticate'));
+        $this->assertEquals('Basic realm="Dagger", charset="UTF-8"', $response->getHeader('WWW-Authenticate'));
         $this->assertEquals(401, $response->getStatus());
 
     }


### PR DESCRIPTION
Fixes #69. Thanks for the suggestion @rfc2822