### PR TITLE
Work around file size issues at 32 Bit systems

### DIFF
--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -88,7 +88,7 @@ class Sapi {
         if ($contentLength !== null) {
             $output = fopen('php://output', 'wb');
             if (is_resource($body) && get_resource_type($body) == 'stream') {
-                if (PHP_INT_SIZE != 4){
+                if (PHP_INT_SIZE !== 4){
                     // use the dedicated function on 64 Bit systems
                     stream_copy_to_stream($body, $output, $contentLength);  
                 } else {

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -88,7 +88,9 @@ class Sapi {
         if ($contentLength !== null) {
             $output = fopen('php://output', 'wb');
             if (is_resource($body) && get_resource_type($body) == 'stream') {
-                stream_copy_to_stream($body, $output, (int)$contentLength);
+                while (!feof($body)) {
+                    fwrite($output,fread($body,8192));    
+                }
             } else {
                 fwrite($output, $body, (int)$contentLength);
             }

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -94,7 +94,7 @@ class Sapi {
                 } else {
                     // workaround for 32 Bit systems to avoid stream_copy_to_stream
                     while (!feof($body)) {
-                        fwrite($output,fread($body,8192));    
+                        fwrite($output, fread($body, 8192));    
                     }   
                 }
             } else {

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -88,14 +88,14 @@ class Sapi {
         if ($contentLength !== null) {
             $output = fopen('php://output', 'wb');
             if (is_resource($body) && get_resource_type($body) == 'stream') {
-                if PHP_INT_SIZE != 4){
+                if (PHP_INT_SIZE != 4){
                     // use the dedicated function on 64 Bit systems
                     stream_copy_to_stream($body, $output, $contentLength);  
                 } else {
                     // workaround for 32 Bit systems to avoid stream_copy_to_stream
                     while (!feof($body)) {
                         fwrite($output,fread($body,8192));    
-                      }   
+                    }   
                 }
             } else {
                 fwrite($output, $body, (int)$contentLength);

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -88,8 +88,14 @@ class Sapi {
         if ($contentLength !== null) {
             $output = fopen('php://output', 'wb');
             if (is_resource($body) && get_resource_type($body) == 'stream') {
-                while (!feof($body)) {
-                    fwrite($output,fread($body,8192));    
+                if PHP_INT_SIZE != 4){
+                    // use the dedicated function on 64 Bit systems
+                    stream_copy_to_stream($body, $output, $contentLength);  
+                } else {
+                    // workaround for 32 Bit systems to avoid stream_copy_to_stream
+                    while (!feof($body)) {
+                        fwrite($output,fread($body,8192));    
+                      }   
                 }
             } else {
                 fwrite($output, $body, (int)$contentLength);


### PR DESCRIPTION
Replace stream_copy_to_stream with a chunked process, to handle file sizes hat do not fit into an integer.
Implementation according to http://php.net/manual/en/function.stream-copy-to-stream.php#98119, proposed and implemented by https://github.com/rikmeijer in https://github.com/nextcloud/server/issues/1707#issuecomment-291835214.