### PR TITLE
move unit tests to phpunit6 style namespaced classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "sabre/uri"    : "^2.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : ">=5.6.0",
+        "phpunit/phpunit" : ">=5.7.0",
         "sabre/cs" : "~1.0.0"
     },
     "suggest" : {

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -90,12 +90,12 @@ class Sapi {
             if (is_resource($body) && get_resource_type($body) == 'stream') {
                 if (PHP_INT_SIZE !== 4){
                     // use the dedicated function on 64 Bit systems
-                    stream_copy_to_stream($body, $output, $contentLength);  
+                    stream_copy_to_stream($body, $output, $contentLength);
                 } else {
                     // workaround for 32 Bit systems to avoid stream_copy_to_stream
                     while (!feof($body)) {
-                        fwrite($output, fread($body, 8192));    
-                    }   
+                        fwrite($output, fread($body, 8192));
+                    }
                 }
             } else {
                 fwrite($output, $body, (int)$contentLength);

--- a/tests/HTTP/Auth/AWSTest.php
+++ b/tests/HTTP/Auth/AWSTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\HTTP\Auth;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 
-class AWSTest extends \PHPUnit_Framework_TestCase {
+class AWSTest extends TestCase {
 
     /**
      * @var Sabre\HTTP\Response

--- a/tests/HTTP/Auth/BasicTest.php
+++ b/tests/HTTP/Auth/BasicTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\HTTP\Auth;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 
-class BasicTest extends \PHPUnit_Framework_TestCase {
+class BasicTest extends TestCase {
 
     function testGetCredentials() {
 

--- a/tests/HTTP/Auth/BearerTest.php
+++ b/tests/HTTP/Auth/BearerTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\HTTP\Auth;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 
-class BearerTest extends \PHPUnit_Framework_TestCase {
+class BearerTest extends TestCase {
 
     function testGetToken() {
 

--- a/tests/HTTP/Auth/DigestTest.php
+++ b/tests/HTTP/Auth/DigestTest.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\HTTP\Auth;
 
+use PHPUnit\Framework\TestCase;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 
-class DigestTest extends \PHPUnit_Framework_TestCase {
+class DigestTest extends TestCase {
 
     /**
      * @var Sabre\HTTP\Response

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class ClientTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase {
 
     function testCreateCurlSettingsArrayGET() {
 

--- a/tests/HTTP/FunctionsTest.php
+++ b/tests/HTTP/FunctionsTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class FunctionsTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class FunctionsTest extends TestCase {
 
     /**
      * @dataProvider getHeaderValuesData

--- a/tests/HTTP/MessageDecoratorTest.php
+++ b/tests/HTTP/MessageDecoratorTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class MessageDecoratorTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class MessageDecoratorTest extends TestCase {
 
     protected $inner;
     protected $outer;

--- a/tests/HTTP/MessageTest.php
+++ b/tests/HTTP/MessageTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class MessageTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class MessageTest extends TestCase {
 
     function testConstruct() {
 

--- a/tests/HTTP/NegotiateTest.php
+++ b/tests/HTTP/NegotiateTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class NegotiateTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class NegotiateTest extends TestCase {
 
     /**
      * @dataProvider negotiateData

--- a/tests/HTTP/RequestDecoratorTest.php
+++ b/tests/HTTP/RequestDecoratorTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class RequestDecoratorTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class RequestDecoratorTest extends TestCase {
 
     protected $inner;
     protected $outer;

--- a/tests/HTTP/RequestTest.php
+++ b/tests/HTTP/RequestTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class RequestTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class RequestTest extends TestCase {
 
     function testConstruct() {
 

--- a/tests/HTTP/ResponseDecoratorTest.php
+++ b/tests/HTTP/ResponseDecoratorTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class ResponseDecoratorTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ResponseDecoratorTest extends TestCase {
 
     protected $inner;
     protected $outer;

--- a/tests/HTTP/ResponseTest.php
+++ b/tests/HTTP/ResponseTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase {
 
     function testConstruct() {
 

--- a/tests/HTTP/SapiTest.php
+++ b/tests/HTTP/SapiTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class SapiTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class SapiTest extends TestCase {
 
     function testConstructFromServerArray() {
 

--- a/tests/HTTP/URLUtilTest.php
+++ b/tests/HTTP/URLUtilTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\HTTP;
 
-class URLUtilTest extends \PHPUnit_Framework_TestCase{
+use PHPUnit\Framework\TestCase;
+
+class URLUtilTest extends TestCase {
 
     function testEncodePath() {
 


### PR DESCRIPTION
The dependency has been bumped to phpunit 5.7 which is forward compatible with the phpunit6 style classes while maintaining  php5.6 compatibility