### PR TITLE
explicitly cast content length to int

### DIFF
--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -90,7 +90,7 @@ class Sapi {
             if (is_resource($body) && get_resource_type($body) == 'stream') {
                 if (PHP_INT_SIZE !== 4){
                     // use the dedicated function on 64 Bit systems
-                    stream_copy_to_stream($body, $output, $contentLength);
+                    stream_copy_to_stream($body, $output, (int)$contentLength);
                 } else {
                     // workaround for 32 Bit systems to avoid stream_copy_to_stream
                     while (!feof($body)) {


### PR DESCRIPTION
Else the unit tests fail with php7