### PR TITLE
Allow NULL body in parseCurlResponse

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -454,7 +454,7 @@ class Client extends EventEmitter
      * @param string   $body
      * @param resource $curlHandle
      */
-    protected function parseCurlResponse(array $headerLines, string $body, $curlHandle): array
+    protected function parseCurlResponse(array $headerLines, string $body = null, $curlHandle): array
     {
         list(
             $curlInfo,

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -387,6 +387,30 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Foo', $result['response']->getBodyAsString());
     }
 
+    public function testParseCurlResultEmptyBody()
+    {
+        $client = new ClientMock();
+        $client->on('curlStuff', function (&$return) {
+            $return = [
+                [
+                    'header_size' => 33,
+                    'http_code' => 200,
+                ],
+                0,
+                '',
+            ];
+        });
+
+        $body = "HTTP/1.1 200 OK\r\nHeader1:Val1\r\n\r\n";
+        $result = $client->parseCurlResult($body, 'foobar');
+
+        $this->assertEquals(Client::STATUS_SUCCESS, $result['status']);
+        $this->assertEquals(200, $result['http_code']);
+        $this->assertEquals(200, $result['response']->getStatus());
+        $this->assertEquals(['Header1' => ['Val1']], $result['response']->getHeaders());
+        $this->assertEquals('', $result['response']->getBodyAsString());
+    }
+
     public function testParseCurlError()
     {
         $client = new ClientMock();


### PR DESCRIPTION
Setting the default for `$body` to `NULL` causes PHP to allow `NULL` as well as `string` for this parameter. The code then seems to work fine when `NULL` is passed.

Fixes #124 