### PR TITLE
chore: remove message from phpstan ignoreErrors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         "sabre/uri"    : "^2.3 || ^3.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.64",
-        "phpstan/phpstan": "^1.11",
+        "friendsofphp/php-cs-fixer": "^3.66",
+        "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-strict-rules": "^1.6",
-        "phpstan/extension-installer": "^1.3",
+        "phpstan/extension-installer": "^1.4",
         "phpunit/phpunit" : "^9.6"
     },
     "suggest" : {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,10 +31,6 @@ parameters:
     count: 1
     path: lib/functions.php
   -
-    message: "#^Offset 'value' on array.* in isset\\(\\) always exists and is not nullable.$#"
-    count: 1
-    path: lib/functions.php
-  -
     message: "#^.* will always evaluate to true\\.$#"
     count: 4
     path: tests/*


### PR DESCRIPTION
This message is no longer emitted by the current phpstan version - good, remove it from `ignoreErrors`

And update the various minor versions of tools mentioned in `composer.json`