### PR TITLE
chore(ci): add PHP 8.5 to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2', '8.3','8.4']
         coverage: ['xdebug']
-        code-style: ['yes']
+        code-style: ['no']
         code-analysis: ['no']
         include:
           - php-versions: '7.4'
@@ -23,7 +23,7 @@ jobs:
             code-analysis: 'yes'
           - php-versions: '8.5'
             coverage: 'xdebug'
-            code-style: 'yes'
+            code-style: 'no'
             code-analysis: 'yes'
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.0', '8.1', '8.2', '8.3','8.4']
         coverage: ['xdebug']
         code-style: ['yes']
         code-analysis: ['no']
@@ -21,7 +21,7 @@ jobs:
             coverage: 'xdebug'
             code-style: 'yes'
             code-analysis: 'yes'
-          - php-versions: '8.4'
+          - php-versions: '8.5'
             coverage: 'xdebug'
             code-style: 'yes'
             code-analysis: 'yes'

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "sabre/uri"    : "^2.3 || ^3.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.87",
+        "friendsofphp/php-cs-fixer": "^3.91",
         "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-strict-rules": "^1.6",


### PR DESCRIPTION
PHP 8.5 works, use it in CI.

Only run php-cs-fixer on the oldest supported PHP 7.4 (when run with PHP 8.* it now tries to apply PHP 8.* code changes, which we don't want just yet)