### PR TITLE
fix(http/client): prefer CURLOPT_PROTOCOLS_STR over deprecated bitmask constants

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -410,10 +410,15 @@ class Client extends EventEmitter
             $settings[CURLOPT_HTTPHEADER] = $nHeaders;
         }
         $settings[CURLOPT_URL] = $request->getUrl();
-        if (defined('CURLOPT_PROTOCOLS')) {
+        // Prefer string-based protocol constants (PHP 8.3+), fall back to
+        // bitmask constants for older PHP versions.  When PHP eventually
+        // removes the bitmask constants the string variant keeps protocol
+        // restrictions in place.
+        if (defined('CURLOPT_PROTOCOLS_STR')) {
+            $settings[CURLOPT_PROTOCOLS_STR] = 'http,https';
+            $settings[CURLOPT_REDIR_PROTOCOLS_STR] = 'http,https';
+        } elseif (defined('CURLOPT_PROTOCOLS')) {
             $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
-        if (defined('CURLOPT_REDIR_PROTOCOLS')) {
             $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
         }
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -414,10 +414,10 @@ class Client extends EventEmitter
         // bitmask constants for older PHP versions.  When PHP eventually
         // removes the bitmask constants the string variant keeps protocol
         // restrictions in place.
-        if (defined('CURLOPT_PROTOCOLS_STR')) {
+        if (defined('CURLOPT_PROTOCOLS_STR') && defined('CURLOPT_REDIR_PROTOCOLS_STR')) {
             $settings[CURLOPT_PROTOCOLS_STR] = 'http,https';
             $settings[CURLOPT_REDIR_PROTOCOLS_STR] = 'http,https';
-        } elseif (defined('CURLOPT_PROTOCOLS')) {
+        } elseif (defined('CURLOPT_PROTOCOLS') && defined('CURLOPT_REDIR_PROTOCOLS')) {
             $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
             $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
         }

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -6,6 +6,28 @@ namespace Sabre\HTTP;
 
 class ClientTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * Returns the expected curl protocol settings depending on available constants.
+     */
+    private static function protocolSettings(): array
+    {
+        if (defined('CURLOPT_PROTOCOLS_STR')) {
+            return [
+                CURLOPT_PROTOCOLS_STR => 'http,https',
+                CURLOPT_REDIR_PROTOCOLS_STR => 'http,https',
+            ];
+        }
+
+        if (defined('CURLOPT_PROTOCOLS')) {
+            return [
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            ];
+        }
+
+        return [];
+    }
+
     public function testCreateCurlSettingsArrayGET(): void
     {
         $client = new ClientMock();
@@ -22,9 +44,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_CUSTOMREQUEST => 'GET',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        ];
+        ] + self::protocolSettings();
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -49,9 +69,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_CUSTOMREQUEST => 'GET',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        ];
+        ] + self::protocolSettings();
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -69,9 +87,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_HTTPHEADER => ['X-Foo: bar'],
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        ];
+        ] + self::protocolSettings();
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -97,9 +113,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_NOBODY => false,
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        ];
+        ] + self::protocolSettings();
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -124,9 +138,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_HTTPHEADER => ['X-Foo: bar'],
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        ];
+        ] + self::protocolSettings();
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -145,9 +157,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_HTTPHEADER => ['X-Foo: bar'],
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        ];
+        ] + self::protocolSettings();
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -8,17 +8,19 @@ class ClientTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Returns the expected curl protocol settings depending on available constants.
+     *
+     * @return array<int,int|string>
      */
     private static function protocolSettings(): array
     {
-        if (defined('CURLOPT_PROTOCOLS_STR')) {
+        if (defined('CURLOPT_PROTOCOLS_STR') && defined('CURLOPT_REDIR_PROTOCOLS_STR')) {
             return [
                 CURLOPT_PROTOCOLS_STR => 'http,https',
                 CURLOPT_REDIR_PROTOCOLS_STR => 'http,https',
             ];
         }
 
-        if (defined('CURLOPT_PROTOCOLS')) {
+        if (defined('CURLOPT_PROTOCOLS') && defined('CURLOPT_REDIR_PROTOCOLS')) {
             return [
                 CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
                 CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,


### PR DESCRIPTION
CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are deprecated at the
libcurl level. When PHP eventually removes the bitmask constants the defined() guards will silently skip protocol restrictions.
This could once become a security issue. It's not an issue right now.
Prefer the string-based constants introduced in PHP 8.3 with fallback to bitmask for older versions.

This is not an urgent fix and I think it's BC
