### PR TITLE
[6.0] fix(http/client): prefer CURLOPT_PROTOCOLS_STR over deprecated bitmask constants

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -409,12 +409,15 @@ class Client extends EventEmitter
             $settings[CURLOPT_HTTPHEADER] = $nHeaders;
         }
         $settings[CURLOPT_URL] = $request->getUrl();
-        // FIXME: CURLOPT_PROTOCOLS is currently unsupported by HHVM
-        if (defined('CURLOPT_PROTOCOLS')) {
+        // Prefer string-based protocol constants (PHP 8.3+), fall back to
+        // bitmask constants for older PHP versions.  When PHP eventually
+        // removes the bitmask constants the string variant keeps protocol
+        // restrictions in place.
+        if (defined('CURLOPT_PROTOCOLS_STR')) {
+            $settings[CURLOPT_PROTOCOLS_STR] = 'http,https';
+            $settings[CURLOPT_REDIR_PROTOCOLS_STR] = 'http,https';
+        } elseif (defined('CURLOPT_PROTOCOLS')) {
             $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
-        // FIXME: CURLOPT_REDIR_PROTOCOLS is currently unsupported by HHVM
-        if (defined('CURLOPT_REDIR_PROTOCOLS')) {
             $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
         }
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -413,10 +413,10 @@ class Client extends EventEmitter
         // bitmask constants for older PHP versions.  When PHP eventually
         // removes the bitmask constants the string variant keeps protocol
         // restrictions in place.
-        if (defined('CURLOPT_PROTOCOLS_STR')) {
+        if (defined('CURLOPT_PROTOCOLS_STR') && defined('CURLOPT_REDIR_PROTOCOLS_STR')) {
             $settings[CURLOPT_PROTOCOLS_STR] = 'http,https';
             $settings[CURLOPT_REDIR_PROTOCOLS_STR] = 'http,https';
-        } elseif (defined('CURLOPT_PROTOCOLS')) {
+        } elseif (defined('CURLOPT_PROTOCOLS') && defined('CURLOPT_REDIR_PROTOCOLS')) {
             $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
             $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
         }

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -8,17 +8,19 @@ class ClientTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Returns the expected curl protocol settings depending on available constants.
+     *
+     * @return array<int,int|string>
      */
     private static function protocolSettings(): array
     {
-        if (defined('CURLOPT_PROTOCOLS_STR')) {
+        if (defined('CURLOPT_PROTOCOLS_STR') && defined('CURLOPT_REDIR_PROTOCOLS_STR')) {
             return [
                 CURLOPT_PROTOCOLS_STR => 'http,https',
                 CURLOPT_REDIR_PROTOCOLS_STR => 'http,https',
             ];
         }
 
-        if (defined('CURLOPT_PROTOCOLS')) {
+        if (defined('CURLOPT_PROTOCOLS') && defined('CURLOPT_REDIR_PROTOCOLS')) {
             return [
                 CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
                 CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -6,6 +6,28 @@ namespace Sabre\HTTP;
 
 class ClientTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * Returns the expected curl protocol settings depending on available constants.
+     */
+    private static function protocolSettings(): array
+    {
+        if (defined('CURLOPT_PROTOCOLS_STR')) {
+            return [
+                CURLOPT_PROTOCOLS_STR => 'http,https',
+                CURLOPT_REDIR_PROTOCOLS_STR => 'http,https',
+            ];
+        }
+
+        if (defined('CURLOPT_PROTOCOLS')) {
+            return [
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            ];
+        }
+
+        return [];
+    }
+
     public function testCreateCurlSettingsArrayGET(): void
     {
         $client = new ClientMock();
@@ -22,7 +44,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_CUSTOMREQUEST => 'GET',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-        ];
+        ] + self::protocolSettings();
 
         // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
         // at least if this unit test fails in the future we know it is :)
@@ -54,9 +76,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_CUSTOMREQUEST => 'GET',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        ];
+        ] + self::protocolSettings();
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -74,7 +94,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_HTTPHEADER => ['X-Foo: bar'],
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-        ];
+        ] + self::protocolSettings();
 
         // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
         // at least if this unit test fails in the future we know it is :)
@@ -107,7 +127,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_NOBODY => false,
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-        ];
+        ] + self::protocolSettings();
 
         // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
         // at least if this unit test fails in the future we know it is :)
@@ -139,7 +159,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_HTTPHEADER => ['X-Foo: bar'],
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-        ];
+        ] + self::protocolSettings();
 
         // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
         // at least if this unit test fails in the future we know it is :)
@@ -165,7 +185,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_HTTPHEADER => ['X-Foo: bar'],
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
-        ];
+        ] + self::protocolSettings();
 
         // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
         // at least if this unit test fails in the future we know it is :)

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -48,13 +48,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
         ] + self::protocolSettings();
 
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
-
         $this->assertEquals($settings, $client->createCurlSettingsArray($request));
     }
 
@@ -98,13 +91,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
         ] + self::protocolSettings();
 
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
-
         $this->assertEquals($settings, $client->createCurlSettingsArray($request));
     }
 
@@ -131,13 +117,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
         ] + self::protocolSettings();
 
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
-
         $this->assertEquals($settings, $client->createCurlSettingsArray($request));
     }
 
@@ -163,13 +142,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
         ] + self::protocolSettings();
 
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
-
         $this->assertEquals($settings, $client->createCurlSettingsArray($request));
     }
 
@@ -188,13 +160,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             CURLOPT_URL => 'http://example.org/',
             CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
         ] + self::protocolSettings();
-
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
 
         $this->assertEquals($settings, $client->createCurlSettingsArray($request));
     }


### PR DESCRIPTION
Backport #272 to 6.0