### PR TITLE
chore: add rector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,18 @@ jobs:
         coverage: ['xdebug']
         code-style: ['no']
         code-analysis: ['no']
+        rector-check: ['no']
         include:
           - php-versions: '7.4'
             coverage: 'xdebug'
             code-style: 'yes'
             code-analysis: 'yes'
+            rector-check: ['no']
           - php-versions: '8.5'
             coverage: 'xdebug'
             code-style: 'no'
             code-analysis: 'yes'
+            rector-check: ['yes']
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -61,6 +64,10 @@ jobs:
 
       - name: Run application server
         run: php -S localhost:8000 -t tests/www 2>/dev/null &
+
+      - name: Code Refactoring (rector)
+        if: matrix.rector-check == 'yes'
+        run: composer rector-check
 
       - name: Test with phpunit
         run: vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit" : "^9.6"
+        "phpunit/phpunit" : "^9.6",
+        "rector/rector": "^2.4"
     },
     "suggest" : {
         "ext-curl" : " to make http requests with the Client class"
@@ -54,6 +55,12 @@
         ],
         "cs-fixer": [
             "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix"
+        ],
+        "rector-check": [
+            "rector process --dry-run"
+        ],
+        "rector-fix": [
+            "rector process"
         ],
         "phpunit": [
             "phpunit --configuration tests/phpunit.xml"

--- a/examples/asyncclient.php
+++ b/examples/asyncclient.php
@@ -37,7 +37,7 @@ for ($i = 0; $i < 1000; ++$i) {
         $request,
 
         // This is the 'success' callback
-        function ($response) use ($i) {
+        function ($response) use ($i): void {
             echo "$i -> ".$response->getStatus()."\n";
         },
 
@@ -45,7 +45,7 @@ for ($i = 0; $i < 1000; ++$i) {
         // problems (such as not being able to connect to a host, dns errors,
         // etc.) and also cases where a response was returned, but it had a
         // status code of 400 or higher.
-        function ($error) use ($i) {
+        function ($error) use ($i): void {
             if (Client::STATUS_CURLERROR === $error['status']) {
                 // Curl errors
                 echo "$i -> curl error: ".$error['curl_errmsg']."\n";

--- a/lib/Auth/AWS.php
+++ b/lib/Auth/AWS.php
@@ -62,7 +62,7 @@ class AWS extends AbstractAuth
             return false;
         }
 
-        list($this->accessKey, $this->signature) = explode(':', $authHeader[1]);
+        [$this->accessKey, $this->signature] = explode(':', $authHeader[1]);
 
         return true;
     }

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -74,7 +74,7 @@ class Client extends EventEmitter
     {
         // See https://github.com/sabre-io/http/pull/115#discussion_r241292068
         // Preserve compatibility for sub-classes that implement their own method `parseCurlResult`
-        $separatedHeaders = __CLASS__ === get_class($this);
+        $separatedHeaders = self::class === get_class($this);
 
         $this->curlSettings = [
             CURLOPT_RETURNTRANSFER => true,
@@ -217,11 +217,7 @@ class Client extends EventEmitter
             if ($status && CURLMSG_DONE === $status['msg']) {
                 $resourceId = (int) $status['handle'];
 
-                list(
-                    $request,
-                    $successCallback,
-                    $errorCallback,
-                    $retryCount) = $this->curlMultiMap[$resourceId];
+                [$request, $successCallback, $errorCallback, $retryCount] = $this->curlMultiMap[$resourceId];
                 unset($this->curlMultiMap[$resourceId]);
 
                 $curlHandle = $status['handle'];

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -173,7 +173,7 @@ class Request extends Message implements RequestInterface
 
         if (0 === strpos($uri, $baseUri)) {
             // We're not interested in the query part (everything after the ?).
-            list($uri) = explode('?', $uri);
+            [$uri] = explode('?', $uri);
 
             return trim(decodePath(substr($uri, strlen($baseUri))), '/');
         }
@@ -260,7 +260,7 @@ class Request extends Message implements RequestInterface
         foreach ($this->getHeaders() as $key => $value) {
             foreach ($value as $v) {
                 if ('Authorization' === $key) {
-                    list($v) = explode(' ', $v, 2);
+                    [$v] = explode(' ', $v, 2);
                     $v .= ' REDACTED';
                 }
                 $out .= $key.': '.$v."\r\n";

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -335,12 +335,12 @@ function parseMimeType(string $str): array
         // Illegal value
         throw new \InvalidArgumentException('Not a valid mime-type: '.$str);
     }
-    list($type, $subType) = $mimeType;
+    [$type, $subType] = $mimeType;
 
     foreach ($parts as $part) {
         $part = trim($part);
         if (strpos($part, '=')) {
-            list($partName, $partValue) =
+            [$partName, $partValue] =
                 explode('=', $part, 2);
         } else {
             $partName = $part;
@@ -374,9 +374,7 @@ function parseMimeType(string $str): array
  */
 function encodePath(string $path): string
 {
-    return preg_replace_callback('/([^A-Za-z0-9_\-\.~\(\)\/:@])/', function ($match) {
-        return '%'.sprintf('%02x', ord($match[0]));
-    }, $path);
+    return preg_replace_callback('/([^A-Za-z0-9_\-\.~\(\)\/:@])/', fn ($match) => '%'.sprintf('%02x', ord($match[0])), $path);
 }
 
 /**
@@ -386,9 +384,7 @@ function encodePath(string $path): string
  */
 function encodePathSegment(string $pathSegment): string
 {
-    return preg_replace_callback('/([^A-Za-z0-9_\-\.~\(\):@])/', function ($match) {
-        return '%'.sprintf('%02x', ord($match[0]));
-    }, $pathSegment);
+    return preg_replace_callback('/([^A-Za-z0-9_\-\.~\(\):@])/', fn ($match) => '%'.sprintf('%02x', ord($match[0])), $pathSegment);
 }
 
 /**

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/examples',
+        __DIR__.'/lib',
+        __DIR__.'/tests',
+    ])
+    ->withPhpSets(false, false, false, false, true)
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/tests/HTTP/Auth/DigestTest.php
+++ b/tests/HTTP/Auth/DigestTest.php
@@ -29,7 +29,7 @@ class DigestTest extends \PHPUnit\Framework\TestCase
 
     public function testDigest(): void
     {
-        list($nonce, $opaque) = $this->getServerTokens();
+        [$nonce, $opaque] = $this->getServerTokens();
 
         $username = 'admin';
         $password = '12345';
@@ -58,7 +58,7 @@ class DigestTest extends \PHPUnit\Framework\TestCase
 
     public function testInvalidDigest(): void
     {
-        list($nonce, $opaque) = $this->getServerTokens();
+        [$nonce, $opaque] = $this->getServerTokens();
 
         $username = 'admin';
         $password = 12345;
@@ -94,7 +94,7 @@ class DigestTest extends \PHPUnit\Framework\TestCase
     public function testDigestAuthInt(): void
     {
         $this->auth->setQOP(Digest::QOP_AUTHINT);
-        list($nonce, $opaque) = $this->getServerTokens(Digest::QOP_AUTHINT);
+        [$nonce, $opaque] = $this->getServerTokens(Digest::QOP_AUTHINT);
 
         $username = 'admin';
         $password = 12345;
@@ -122,7 +122,7 @@ class DigestTest extends \PHPUnit\Framework\TestCase
     public function testDigestAuthBoth(): void
     {
         $this->auth->setQOP(Digest::QOP_AUTHINT | Digest::QOP_AUTH);
-        list($nonce, $opaque) = $this->getServerTokens(Digest::QOP_AUTHINT | Digest::QOP_AUTH);
+        [$nonce, $opaque] = $this->getServerTokens(Digest::QOP_AUTHINT | Digest::QOP_AUTH);
 
         $username = 'admin';
         $password = 12345;

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -192,7 +192,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $client = new ClientMock();
         $request = new Request('GET', 'http://example.org/');
 
-        $client->on('doRequest', function ($request, &$response) {
+        $client->on('doRequest', function ($request, &$response): void {
             $response = new Response(200);
         });
 
@@ -231,7 +231,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $maxPeakMemoryUsageEnvVariable = 'SABRE_HTTP_TEST_GET_LARGE_CONTENT_MAX_PEAK_MEMORY_USAGE';
         $maxPeakMemoryUsage = \getenv($maxPeakMemoryUsageEnvVariable);
         if (false === $maxPeakMemoryUsage) {
-            $maxPeakMemoryUsage = 60 * pow(1024, 2);
+            $maxPeakMemoryUsage = 60 * 1024 ** 2;
         }
 
         $request = new Request('GET', $url);
@@ -259,11 +259,11 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $client = new Client();
 
         $request = new Request('GET', $url);
-        $client->sendAsync($request, function (ResponseInterface $response) {
+        $client->sendAsync($request, function (ResponseInterface $response): void {
             self::assertEquals("foo\n", $response->getBody());
             self::assertEquals(200, $response->getStatus());
             self::assertEquals(4, $response->getHeader('Content-Length'));
-        }, function ($error) use ($request) {
+        }, function ($error) use ($request): void {
             $url = $request->getUrl();
             self::fail("Failed to GET $url");
         });
@@ -284,22 +284,22 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $client = new Client();
 
         $request = new Request('GET', $url);
-        $client->sendAsync($request, function (ResponseInterface $response) {
+        $client->sendAsync($request, function (ResponseInterface $response): void {
             self::assertEquals("foo\n", $response->getBody());
             self::assertEquals(200, $response->getStatus());
             self::assertEquals(4, $response->getHeader('Content-Length'));
-        }, function ($error) use ($request) {
+        }, function ($error) use ($request): void {
             $url = $request->getUrl();
             self::fail("Failed to get $url");
         });
 
         $url = $this->getAbsoluteUrl('/bar.php');
         $request = new Request('GET', $url);
-        $client->sendAsync($request, function (ResponseInterface $response) {
+        $client->sendAsync($request, function (ResponseInterface $response): void {
             self::assertEquals("bar\n", $response->getBody());
             self::assertEquals(200, $response->getStatus());
             self::assertEquals('Bar', $response->getHeader('X-Test'));
-        }, function ($error) use ($request) {
+        }, function ($error) use ($request): void {
             $url = $request->getUrl();
             self::fail("Failed to get $url");
         });
@@ -312,11 +312,11 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $client = new ClientMock();
         $request = new Request('GET', 'http://example.org/');
 
-        $client->on('doRequest', function ($request, &$response) {
+        $client->on('doRequest', function ($request, &$response): void {
             throw new ClientException('aaah', 1);
         });
         $called = false;
-        $client->on('exception', function () use (&$called) {
+        $client->on('exception', function () use (&$called): void {
             $called = true;
         });
 
@@ -333,14 +333,14 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $client = new ClientMock();
         $request = new Request('GET', 'http://example.org/');
 
-        $client->on('doRequest', function ($request, &$response) {
+        $client->on('doRequest', function ($request, &$response): void {
             $response = new Response(404);
         });
         $called = 0;
-        $client->on('error', function () use (&$called) {
+        $client->on('error', function () use (&$called): void {
             ++$called;
         });
-        $client->on('error:404', function () use (&$called) {
+        $client->on('error:404', function () use (&$called): void {
             ++$called;
         });
 
@@ -354,7 +354,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $request = new Request('GET', 'http://example.org/');
 
         $called = 0;
-        $client->on('doRequest', function ($request, &$response) use (&$called) {
+        $client->on('doRequest', function ($request, &$response) use (&$called): void {
             ++$called;
             if ($called < 3) {
                 $response = new Response(404);
@@ -364,7 +364,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         });
 
         $errorCalled = 0;
-        $client->on('error', function ($request, $response, &$retry, $retryCount) use (&$errorCalled) {
+        $client->on('error', function ($request, $response, &$retry, $retryCount) use (&$errorCalled): void {
             ++$errorCalled;
             $retry = true;
         });
@@ -381,7 +381,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $client->setThrowExceptions(true);
         $request = new Request('GET', 'http://example.org/');
 
-        $client->on('doRequest', function ($request, &$response) {
+        $client->on('doRequest', function ($request, &$response): void {
             $response = new Response(404);
         });
 
@@ -390,14 +390,14 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             self::fail('An exception should have been thrown');
         } catch (ClientHttpException $e) {
             self::assertEquals(404, $e->getHttpStatus());
-            self::assertInstanceOf('Sabre\HTTP\Response', $e->getResponse());
+            self::assertInstanceOf(Response::class, $e->getResponse());
         }
     }
 
     public function testParseCurlResult(): void
     {
         $client = new ClientMock();
-        $client->on('curlStuff', function (&$return) {
+        $client->on('curlStuff', function (&$return): void {
             $return = [
                 [
                     'header_size' => 33,
@@ -422,7 +422,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     public function testParseCurlResultEmptyBody(): void
     {
         $client = new ClientMock();
-        $client->on('curlStuff', function (&$return) {
+        $client->on('curlStuff', function (&$return): void {
             $return = [
                 [
                     'header_size' => 33,
@@ -447,7 +447,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     public function testParseCurlError(): void
     {
         $client = new ClientMock();
-        $client->on('curlStuff', function (&$return) {
+        $client->on('curlStuff', function (&$return): void {
             $return = [
                 [],
                 1,
@@ -468,10 +468,10 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     {
         $client = new ClientMock();
         $request = new Request('GET', 'http://example.org/');
-        $client->on('curlExec', function (&$return) {
+        $client->on('curlExec', function (&$return): void {
             $return = "HTTP/1.1 200 OK\r\nHeader1:Val1\r\n\r\nFoo";
         });
-        $client->on('curlStuff', function (&$return) {
+        $client->on('curlStuff', function (&$return): void {
             $return = [
                 [
                     'header_size' => 33,
@@ -491,10 +491,10 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     {
         $client = new ClientMock();
         $request = new Request('GET', 'http://example.org/');
-        $client->on('curlExec', function (&$return) {
+        $client->on('curlExec', function (&$return): void {
             $return = '';
         });
-        $client->on('curlStuff', function (&$return) {
+        $client->on('curlStuff', function (&$return): void {
             $return = [
                 [],
                 1,

--- a/tests/HTTP/MessageTest.php
+++ b/tests/HTTP/MessageTest.php
@@ -9,7 +9,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
     public function testConstruct(): void
     {
         $message = new MessageMock();
-        self::assertInstanceOf('Sabre\HTTP\Message', $message);
+        self::assertInstanceOf(Message::class, $message);
     }
 
     public function testStreamBody(): void
@@ -270,7 +270,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
      */
     private function createCallback($content)
     {
-        return function () use ($content) {
+        return function () use ($content): void {
             echo $content;
         };
     }

--- a/tests/HTTP/SapiTest.php
+++ b/tests/HTTP/SapiTest.php
@@ -286,7 +286,7 @@ class SapiTest extends \PHPUnit\Framework\TestCase
      */
     public function testSendWorksWithCallbackAsBody(): void
     {
-        $response = new Response(200, [], function () {
+        $response = new Response(200, [], function (): void {
             $fd = fopen('php://output', 'r+');
             fwrite($fd, 'foo');
             fclose($fd);


### PR DESCRIPTION
Doing this first with the code that still supports PHP 7.4.
That will make it easier when backporting any future patches - the starting point of the 7.0 minor version code will be close to what is in master.

rector only made small changes to production code. Most of the changes were in test code.