### PR TITLE
ci: fix rector-check settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
             coverage: 'xdebug'
             code-style: 'yes'
             code-analysis: 'yes'
-            rector-check: ['no']
+            rector-check: 'no'
           - php-versions: '8.5'
             coverage: 'xdebug'
             code-style: 'no'
             code-analysis: 'yes'
-            rector-check: ['yes']
+            rector-check: 'yes'
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
So that `rector` actually runs in CI.