### PR TITLE
test: migrate to phpunit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit" : "^10.5",
+        "phpunit/phpunit" : "^11.5",
         "rector/rector": "^2.4"
     },
     "suggest" : {

--- a/tests/HTTP/FunctionsTest.php
+++ b/tests/HTTP/FunctionsTest.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Sabre\HTTP;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class FunctionsTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @dataProvider getHeaderValuesDataOnValues2
-     *
      * @param array<int, string> $result
      * @param array<int, string> $values1
      * @param array<int, string> $values2
      */
+    #[DataProvider('getHeaderValuesDataOnValues2')]
     public function testGetHeaderValuesOnValues2(array $result, array $values1, array $values2): void
     {
         self::assertEquals($result, getHeaderValues($values1, $values2));
@@ -38,11 +39,10 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider getHeaderValuesData
-     *
      * @param string            $input
      * @param array<int, mixed> $output
      */
+    #[DataProvider('getHeaderValuesData')]
     public function testGetHeaderValues($input, array $output): void
     {
         self::assertEquals(
@@ -81,11 +81,10 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider preferData
-     *
      * @param string            $input
      * @param array<int, mixed> $output
      */
+    #[DataProvider('preferData')]
     public function testPrefer($input, array $output): void
     {
         self::assertEquals(

--- a/tests/HTTP/NegotiateTest.php
+++ b/tests/HTTP/NegotiateTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Sabre\HTTP;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class NegotiateTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @dataProvider negotiateData
-     *
      * @param array<mixed, mixed> $available
      */
+    #[DataProvider('negotiateData')]
     public function testNegotiate(?string $acceptHeader, array $available, ?string $expected): void
     {
         self::assertEquals(

--- a/tests/HTTP/SapiTest.php
+++ b/tests/HTTP/SapiTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Sabre\HTTP;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+
 class SapiTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructFromServerArray(): void
@@ -144,9 +147,8 @@ class SapiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @runInSeparateProcess
-     *
-     * @depends testSend
      */
+    #[Depends('testSend')]
     public function testSendLimitedByContentLengthString(): void
     {
         $response = new Response(200);
@@ -180,9 +182,8 @@ class SapiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @runInSeparateProcess
-     *
-     * @depends testSend
      */
+    #[Depends('testSend')]
     public function testSendLimitedByContentLengthStream(): void
     {
         $response = new Response(200, ['Content-Length' => 19]);
@@ -205,17 +206,15 @@ class SapiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @runInSeparateProcess
-     *
-     * @depends testSend
-     *
-     * @dataProvider sendContentRangeStreamData
      */
+    #[Depends('testSend')]
+    #[DataProvider('sendContentRangeStreamData')]
     public function testSendContentRangeStream(
         string $ignoreAtStart,
         string $sendText,
         int $multiplier,
         string $ignoreAtEnd,
-        ?int $contentLength): void
+        ?int $contentLength = null): void
     {
         $partial = str_repeat($sendText, $multiplier);
         $ignoreAtStartLength = strlen($ignoreAtStart);
@@ -281,9 +280,8 @@ class SapiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @runInSeparateProcess
-     *
-     * @depends testSend
      */
+    #[Depends('testSend')]
     public function testSendWorksWithCallbackAsBody(): void
     {
         $response = new Response(200, [], function (): void {

--- a/tests/HTTP/URLUtilTest.php
+++ b/tests/HTTP/URLUtilTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sabre\HTTP;
 
+use PHPUnit\Framework\Attributes\Depends;
+
 class URLUtilTest extends \PHPUnit\Framework\TestCase
 {
     public function testEncodePath(): void
@@ -61,9 +63,7 @@ class URLUtilTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('Hello Test+Test2.txt', $newStr);
     }
 
-    /**
-     * @depends testDecode
-     */
+    #[Depends('testDecode')]
     public function testDecodeUmlaut(): void
     {
         $str = 'Hello%C3%BC.txt';
@@ -71,9 +71,7 @@ class URLUtilTest extends \PHPUnit\Framework\TestCase
         self::assertEquals("Hello\xC3\xBC.txt", $newStr);
     }
 
-    /**
-     * @depends testDecode
-     */
+    #[Depends('testDecode')]
     public function testDecodeSlavicWords(): void
     {
         $words = [
@@ -90,9 +88,7 @@ class URLUtilTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @depends testDecodeUmlaut
-     */
+    #[Depends('testDecodeUmlaut')]
     public function testDecodeUmlautLatin1(): void
     {
         $str = 'Hello%FC.txt';
@@ -102,9 +98,8 @@ class URLUtilTest extends \PHPUnit\Framework\TestCase
 
     /**
      * This testcase was sent by a bug reporter.
-     *
-     * @depends testDecode
      */
+    #[Depends('testDecode')]
     public function testDecodeAccentsWindows7(): void
     {
         $str = '/webdav/%C3%A0fo%C3%B3';


### PR DESCRIPTION
convert test annotations to PHP attributes

The XML schema is the same for PHPunit 10 and 11,
so that does not need to be migrated.