### PR TITLE
refactor: Always use hash_hmac

### DIFF
--- a/lib/Auth/AWS.php
+++ b/lib/Auth/AWS.php
@@ -107,16 +107,14 @@ class AWS extends AbstractAuth
 
         $amzHeaders = $this->getAmzHeaders();
 
-        $signature = base64_encode(
-            $this->hmacsha1($secretKey,
-                $this->request->getMethod()."\n".
+        $message = $this->request->getMethod()."\n".
                 $contentMD5."\n".
                 $this->request->getHeader('Content-type')."\n".
                 $requestDate."\n".
                 $amzHeaders.
-                $this->request->getUrl()
-            )
-        );
+                $this->request->getUrl();
+
+        $signature = base64_encode(hash_hmac('sha1', $message, $secretKey, true));
 
         if ($this->signature !== $signature) {
             $this->errorCode = self::ERR_INVALIDSIGNATURE;
@@ -191,26 +189,5 @@ class AWS extends AbstractAuth
         }
 
         return $headerStr;
-    }
-
-    /**
-     * Generates an HMAC-SHA1 signature.
-     */
-    private function hmacsha1(string $key, string $message): string
-    {
-        if (function_exists('hash_hmac')) {
-            return hash_hmac('sha1', $message, $key, true);
-        }
-
-        $blocksize = 64;
-        if (strlen($key) > $blocksize) {
-            $key = pack('H*', sha1($key));
-        }
-        $key = str_pad($key, $blocksize, chr(0x00));
-        $ipad = str_repeat(chr(0x36), $blocksize);
-        $opad = str_repeat(chr(0x5C), $blocksize);
-        $hmac = pack('H*', sha1(($key ^ $opad).pack('H*', sha1(($key ^ $ipad).$message))));
-
-        return $hmac;
     }
 }

--- a/tests/HTTP/Auth/AWSTest.php
+++ b/tests/HTTP/Auth/AWSTest.php
@@ -200,21 +200,4 @@ class AWSTest extends \PHPUnit\Framework\TestCase
         $test = preg_match('/^AWS$/', (string) $this->response->getHeader('WWW-Authenticate'), $matches);
         self::assertTrue(1 === $test, 'The WWW-Authenticate response didn\'t match our pattern');
     }
-
-    /**
-     * Generates an HMAC-SHA1 signature.
-     */
-    private function hmacsha1(string $key, string $message): string
-    {
-        $blocksize = 64;
-        if (strlen($key) > $blocksize) {
-            $key = pack('H*', sha1($key));
-        }
-        $key = str_pad($key, $blocksize, chr(0x00));
-        $ipad = str_repeat(chr(0x36), $blocksize);
-        $opad = str_repeat(chr(0x5C), $blocksize);
-        $hmac = pack('H*', sha1(($key ^ $opad).pack('H*', sha1(($key ^ $ipad).$message))));
-
-        return $hmac;
-    }
 }

--- a/tests/HTTP/Auth/AWSTest.php
+++ b/tests/HTTP/Auth/AWSTest.php
@@ -175,9 +175,7 @@ class AWSTest extends \PHPUnit\Framework\TestCase
         $date->setTimezone(new \DateTimeZone('GMT'));
         $date = $date->format('D, d M Y H:i:s \\G\\M\\T');
 
-        $sig = base64_encode($this->hmacsha1($secretKey,
-            "POST\n$contentMD5\n\n$date\nx-amz-date:$date\n/evert"
-        ));
+        $sig = base64_encode(hash_hmac('sha1', "POST\n$contentMD5\n\n$date\nx-amz-date:$date\n/evert", $secretKey, true));
 
         $this->request->setUrl('/evert');
         $this->request->setMethod('POST');


### PR DESCRIPTION
We now depends on PHP 8.2 where this method is part of the core.

Fix #193 